### PR TITLE
Fixed DateTime() typo

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -466,17 +466,17 @@ HTML
             $interval = $this->deriveInterval($interval);
             switch (strtolower($date)) {
                 case "curdate()":
-                    $objDate = new Datetime($this->curdate());
+                    $objDate = new DateTime($this->curdate());
                     $objDate->add(new DateInterval($interval));
                     $formatted = $objDate->format("Y-m-d");
                     break;
                 case "now()":
-                    $objDate = new Datetime($this->now());
+                    $objDate = new DateTime($this->now());
                     $objDate->add(new DateInterval($interval));
                     $formatted = $objDate->format("Y-m-d H:i:s");
                     break;
                 default:
-                    $objDate = new Datetime($date);
+                    $objDate = new DateTime($date);
                     $objDate->add(new DateInterval($interval));
                     $formatted = $objDate->format("Y-m-d H:i:s");
             }
@@ -502,17 +502,17 @@ HTML
             $interval = $this->deriveInterval($interval);
             switch (strtolower($date)) {
                 case "curdate()":
-                    $objDate = new Datetime($this->curdate());
+                    $objDate = new DateTime($this->curdate());
                     $objDate->sub(new DateInterval($interval));
                     $returnval = $objDate->format("Y-m-d");
                     break;
                 case "now()":
-                    $objDate = new Datetime($this->now());
+                    $objDate = new DateTime($this->now());
                     $objDate->sub(new DateInterval($interval));
                     $returnval = $objDate->format("Y-m-d H:i:s");
                     break;
                 default:
-                    $objDate = new Datetime($date);
+                    $objDate = new DateTime($date);
                     $objDate->sub(new DateInterval($interval));
                     $returnval = $objDate->format("Y-m-d H:i:s");
             }

--- a/src/db.php
+++ b/src/db.php
@@ -16,6 +16,7 @@
 
 namespace WP_SQLite_DB {
 
+	use DateTime;
     use PDO;
     use PDOException;
 

--- a/src/db.php
+++ b/src/db.php
@@ -16,7 +16,7 @@
 
 namespace WP_SQLite_DB {
 
-	use DateTime;
+    use DateTime;
     use PDO;
     use PDOException;
 


### PR DESCRIPTION
Fixed a typo with `DateTime()` used in functions `date_add()` and `date_sub()` respectively.