### PR TITLE
Support for PHP8

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -1333,7 +1333,7 @@ HTML
          * @return mixed according to the query type
          * @see PDO::query()
          */
-        public function query($statement, $mode = PDO::ATTR_DEFAULT_FETCH_MODE, $arg3 = null, array $ctorargs = [])
+        public function query($statement, $mode = PDO::ATTR_DEFAULT_FETCH_MODE, mixed ...$ctorargs)
         {
             $this->flush();
 

--- a/src/db.php
+++ b/src/db.php
@@ -6,7 +6,7 @@
  * Author URI: https://aaemnnost.tv
  * Plugin URI: https://github.com/aaemnnosttv/wp-sqlite-db
  * Version: 1.1.0
- * Requires PHP: 5.4
+ * Requires PHP: 5.6
  *
  * This file must be placed in wp-content/db.php.
  * WordPress loads this file automatically.

--- a/src/db.php
+++ b/src/db.php
@@ -888,9 +888,6 @@ HTML
          *
          * This function compares two dates value and returns the difference.
          *
-         * PHP 5.3.2 has a serious bug in DateTime::diff(). So if users' PHP is that version,
-         * we don't use that function. See https://bugs.php.net/bug.php?id=51184.
-         *
          * @param string start
          * @param string end
          *
@@ -898,19 +895,11 @@ HTML
          */
         public function datediff($start, $end)
         {
-            if (version_compare(PHP_VERSION, '5.3.2', '==')) {
-                $start_date = strtotime($start);
-                $end_date = strtotime($end);
-                $interval = floor(($start_date - $end_date) / (3600 * 24));
+			$start_date = new DateTime($start);
+			$end_date = new DateTime($end);
+			$interval = $end_date->diff($start_date, false);
 
-                return $interval;
-            } else {
-                $start_date = new DateTime($start);
-                $end_date = new DateTime($end);
-                $interval = $end_date->diff($start_date, false);
-
-                return $interval->format('%r%a');
-            }
+			return $interval->format('%r%a');
         }
 
         /**


### PR DESCRIPTION
Hi,

My branch php8 present changes for support php8. I used commits from forks:
https://github.com/hasinhayder/wp-sqlite-db/commit/451438cba929daa27f63c94600f80f0575f589a3
https://github.com/aaemnnosttv/wp-sqlite-db/pull/11/commits/ca6ac13715b79ed517573608f5bbca44f931ee2b

Changes for php 8 require a minimum version to run at least php 5.6.
