### PR TITLE
Add support for composer/installers v1 and v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "require": {
         "php": ">=5.6",
         "ext-PDO": "*",
-        "composer/installers": "^1.0"
+        "composer/installers": "^1.0 || ^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5 || ^6 || ^7",


### PR DESCRIPTION
Provide support for [composer/installers](https://github.com/composer/installers) versions 1 and 2, for peer dependencies that might require the latter.