### PR TITLE
Implement SQLite db_server_info

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -2818,6 +2818,16 @@ HTML
         {
             return '5.5';
         }
+
+        /**
+         * Retrieves full database server information.
+         *
+         * @return string|false Server info on success, false on failure.
+         */
+        public function db_server_info()
+        {
+            return SQLite3::version()['versionString'] . '-SQLite3';
+        }
     }
 
 

--- a/src/db.php
+++ b/src/db.php
@@ -20,6 +20,7 @@ namespace WP_SQLite_DB {
     use DateInterval;
     use PDO;
     use PDOException;
+    use SQLite3;
 
     if (! defined('ABSPATH')) {
         exit;
@@ -2816,6 +2817,7 @@ HTML
          */
         public function db_version()
         {
+            // WordPress currently requires this to be 5.0 or greater.
             return '5.5';
         }
 


### PR DESCRIPTION
This PR implements the `wpdb::db_server_info` method in a way which is closest to the format returned by `mysqli_get_server_info`.

Fixes #44 