### PR TITLE
fix: handle deprecation notices in PHP 8.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['5.6', '7.4', '8.0']
+        php-version: ['5.6', '7.4', '8.0', '8.1']
     steps:
       - uses: actions/checkout@v3
       

--- a/src/db.php
+++ b/src/db.php
@@ -1319,9 +1319,9 @@ HTML
          * @param int $mode
          * @param array $fetch_mode_args
          *
-         * @return mixed according to the query type
          * @see PDO::query()
          */
+        #[\ReturnTypeWillChange]
         public function query($statement, $mode = PDO::ATTR_DEFAULT_FETCH_MODE, ...$fetch_mode_args)
         {
             $this->flush();
@@ -2425,17 +2425,16 @@ HTML
          * Method to call PDO::beginTransaction().
          *
          * @see PDO::beginTransaction()
-         * @return boolean
          */
-        public function beginTransaction()
+        public function beginTransaction(): bool
         {
             if ($this->has_active_transaction) {
                 return false;
-            } else {
-                $this->has_active_transaction = $this->pdo->beginTransaction();
-
-                return $this->has_active_transaction;
             }
+
+            $this->has_active_transaction = $this->pdo->beginTransaction();
+
+            return $this->has_active_transaction;
         }
 
         /**
@@ -2443,10 +2442,12 @@ HTML
          *
          * @see PDO::commit()
          */
-        public function commit()
+        public function commit(): bool
         {
-            $this->pdo->commit();
+            $isSuccess = $this->pdo->commit();
             $this->has_active_transaction = false;
+
+            return $isSuccess;
         }
 
         /**
@@ -2454,10 +2455,12 @@ HTML
          *
          * @see PDO::rollBack()
          */
-        public function rollBack()
+        public function rollBack(): bool
         {
-            $this->pdo->rollBack();
+            $isSuccess = $this->pdo->rollBack();
             $this->has_active_transaction = false;
+
+            return $isSuccess;
         }
     }
 

--- a/src/db.php
+++ b/src/db.php
@@ -2426,7 +2426,8 @@ HTML
          *
          * @see PDO::beginTransaction()
          */
-        public function beginTransaction(): bool
+        #[\ReturnTypeWillChange]
+        public function beginTransaction()
         {
             if ($this->has_active_transaction) {
                 return false;
@@ -2442,7 +2443,8 @@ HTML
          *
          * @see PDO::commit()
          */
-        public function commit(): bool
+        #[\ReturnTypeWillChange]
+        public function commit()
         {
             $isSuccess = $this->pdo->commit();
             $this->has_active_transaction = false;
@@ -2455,7 +2457,8 @@ HTML
          *
          * @see PDO::rollBack()
          */
-        public function rollBack(): bool
+        #[\ReturnTypeWillChange]
+        public function rollBack()
         {
             $isSuccess = $this->pdo->rollBack();
             $this->has_active_transaction = false;

--- a/src/db.php
+++ b/src/db.php
@@ -1319,6 +1319,7 @@ HTML
          * @param int $mode
          * @param array $fetch_mode_args
          *
+         * @return mixed according to the query type
          * @see PDO::query()
          */
         #[\ReturnTypeWillChange]
@@ -2425,6 +2426,7 @@ HTML
          * Method to call PDO::beginTransaction().
          *
          * @see PDO::beginTransaction()
+         * @return boolean
          */
         #[\ReturnTypeWillChange]
         public function beginTransaction()


### PR DESCRIPTION
Hi, everyone! This pull request solves deprecation notices and untreated errors, new after upgrading to PHP 8.1. 

The PDOEngine class extends from the PHP PDO class, but with no indication of the return code or a signature mismatch in some methods. Starting in PHP 8.1 not being explicit on the return types (or returning anything different from the parent method) leads to a deprecation notice and untreated errors.

There were four methods to adjust. Three of them were easy fixes/enhancements.

- commit and rollBack were expected to return a boolean but there was no return at all
- beginTransaction just needed to be adjusted for a default return value (also expected to be a boolean)

The fourth method is query. The way query was implemented, changed a lot the original PDO query response behavior. It gets the job done but also introduces new challenges to make the code compliant with the original signature/return type, leading to a deprecation warning.

The original PDO query always returns a PDOStatement object, or false on any failure. The current PDOEngine, as implemented, could return (from my initial analysis) undefined, true, false, PDOStatement objects and even integers.

For this reason, I believe it’s a fair decision to use the #[\ReturnTypeWillChange] annotation in this case. In the near future, I suggest someone should review and refactor the codebase. There will be some breaking changes, but I believe it's an important step towards PHP 8.3 (that I believe should be launched by the end of next year) and even a future PHP 9, where I also believe the #[\ReturnTypeWillChange]
will be retired.

After those changes, all tests passed.

Solves #27 
Solves #49 

I hope my analysis and this PR help the project in any way.
Best regards and Merry Christmas!