### PR TITLE
Update the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,17 +30,17 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
 
-      - name: Install Composer dependencies
-        uses: ramsey/composer-install@v2
-        with:
-          # Bust the cache at least once a month - output format: YYYY-MM.
-          custom-cache-suffix: $(date -u "+%Y-%m")
-
       - name: 'Validate composer.json'
         run: composer validate --strict
 
       - name: 'Validate PHP syntax'
         run: php -l src/db.php
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v2
+        with:
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Run tests
         run: composer test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,34 +2,45 @@ name: Test
 
 on:
   pull_request:
-    paths:
-      - src/**
-      - tests/**
-      - 'phpunit.xml*'
-      - 'composer.*'
+    branches:
+      - 'master'
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: true
 
 jobs:
   integration:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: ['5.6', '7.4', '8.0', '8.1']
+        php-version: ['5.6', '7.4', '8.0', '8.1', '8.2', '8.3']
+
+    name: Unit tests on PHP ${{ matrix.php-version }}
+
+    continue-on-error: ${{ matrix.php-version == '8.3' }}
+
     steps:
       - uses: actions/checkout@v3
-      
+
       - uses: shivammathur/setup-php@v2
         with:
-          tools: composer
           php-version: ${{ matrix.php-version }}
+
+      - name: Install Composer dependencies
+        uses: ramsey/composer-install@v2
+        with:
+          # Bust the cache at least once a month - output format: YYYY-MM.
+          custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: 'Validate composer.json'
         run: composer validate --strict
 
       - name: 'Validate PHP syntax'
         run: php -l src/db.php
-
-      - run: composer install
 
       - name: Run tests
         run: composer test


### PR DESCRIPTION
I've updated the GH Actions test matrix.

The updates consider of:

- Changing paths being checked, and instead adding a branch
- Adding concurrency to save GH Action resources in the case that multiple actions are triggered
- Add PHP 8.2 and PHP 8.3 to the test matrix (8.3 is allowed to fail, as it's in development still)
- Simplify the Composer installation step by using the [ramsey/composer-install](https://github.com/ramsey/composer-install) action

I can see some other potential improvements and will branch off of this branch and make a subsequent PR for those, so as to not pollute this PR.

Closes #51 