### PR TITLE
Column names from DESCRIBE table to lowercase to match MySQL

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -2270,7 +2270,7 @@ HTML
             } else {
                 foreach ($this->_results as $row) {
                     $_columns['Field'] = $row->name;
-                    $_columns['Type'] = $row->type;
+                    $_columns['Type'] = strtolower($row->type);
                     $_columns['Null'] = $row->notnull ? "NO" : "YES";
                     $_columns['Key'] = $row->pk ? "PRI" : "";
                     $_columns['Default'] = $row->dflt_value;


### PR DESCRIPTION
wp-cli's search-replace command fails when used against a WordPress installation using wp-sqlite-db, because it looks for text columns in tables by checking the output of `DESCRIBE tablename` for column types with `text` or `varchar` in them, case-sensitively. (See https://github.com/wp-cli/search-replace-command/blob/main/src/Search_Replace_Command.php#L714 for the details; they use `strpos` to check.)

SQLite (and wp-sqlite-db) returns column type as `TEXT`, which does not match. This means that search-replace fails because it doesn't detect any text columns in tables.

It would be nice if they used `stripos` (and I will file a PR over there as well), but making the wp-sqlite-db code convert the returned column type to lowercase fixes this problem, and makes it match MySQL's response more accurately, which seems like a good thing all round.