### PR TITLE
Bump db_version to 8.0

### DIFF
--- a/src/db.php
+++ b/src/db.php
@@ -2826,8 +2826,8 @@ HTML
          */
         public function db_version()
         {
-            // WordPress currently requires this to be 5.0 or greater.
-            return '5.5';
+            // WordPress currently requires this to be 5.5.5 or greater.
+            return '8.0';
         }
 
         /**


### PR DESCRIPTION
## What is this?
WordPress's minimum MySQL version [was recently bumped to 5.5.5](https://make.wordpress.org/core/2023/12/08/raising-the-minimum-version-of-mysql-required-in-wordpress-6-5/), which means this plugin no longer works with WordPress trunk. Let's bump the reported DB version to 8.0 to make it last a while.

Version bump was done here:
https://github.com/WordPress/wordpress-develop/commit/e1265a3732eedaf6bf12f87b080e19ebd65a08a6

Also see this for a similar change:
https://github.com/WordPress/sqlite-database-integration/commit/768f8cc6d2a2707f744bba31cb0e5421a68c0f4f

## Why do this?
Even though there is a [canonical plugin](https://github.com/WordPress/sqlite-database-integration) furthering this work, this dropin remains an easy, scriptable way to use SQLite on a new WordPress install without a MySQL server requirement.